### PR TITLE
Add nightly and rust-src to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ Firmware version: v0.6.2
 # Dependencies
 
 - Embedded ARM toolchain. Any recent version should do.
-- Rust toolchain. See https://rustup.rs
-- Xargo. `$ cargo install xargo`
+- Rust nightly toolchain. See https://rustup.rs
+- Xargo. `$ rustup run nightly cargo install xargo`
+- The rust-src component for nightly: `$ rustup default nightly && rustup
+  component add rust-src` If you don't want to keep nightly as the default, you
+  can revert the change after installing the `rust-src` component.
 - `crc32` and `xxd`. Check how your distribution ships these binaries.
 
 # How to use


### PR DESCRIPTION
I use stable as default toolchain. Some things tripped me up:

- The nightly requirement wasn't documented. Error messages are strange
  if it isn't used.
- The rust-src component must be installed. For some reason, this only
  seems to work if nightly is set as default chain.