### PR TITLE
memory safe data sharing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "photon-quickstart"
 version = "0.1.0"
 
 [dependencies]
-particle-hal = { git = "https://github.com/japaric/particle-hal" }
+photon-hal = { git = "https://github.com/japaric/photon-hal" }
 photon = { git = "https://github.com/japaric/photon" }
 
 [profile.dev]

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -2,11 +2,12 @@
 
 #![no_std]
 
-extern crate particle_hal as hal;
 #[macro_use]
 extern crate photon;
+extern crate photon_hal as hal;
 
 use hal::{LED, PinMode};
+use photon::App;
 
 const PERIOD: u32 = 250; // ms
 
@@ -15,13 +16,13 @@ app! {
     loop: loop_,
 }
 
-fn setup() {
+fn setup(_: App) {
     LED.pin_mode(PinMode::Output);
 }
 
-fn loop_() {
+fn loop_(ref mut app: App) {
     LED.low();
-    hal::sleep_ms(PERIOD);
+    app.delay_ms(PERIOD);
     LED.high();
-    hal::sleep_ms(PERIOD);
+    app.delay_ms(PERIOD);
 }

--- a/examples/deviceid.rs
+++ b/examples/deviceid.rs
@@ -2,11 +2,12 @@
 
 #![no_std]
 
-extern crate particle_hal as hal;
 #[macro_use]
 extern crate photon;
+extern crate photon_hal as hal;
 
 use hal::UsbSerial;
+use photon::App;
 
 const PERIOD: u32 = 1_000; // ms
 const BAUD_RATE: u32 = 115_200;
@@ -16,11 +17,11 @@ app! {
     loop: loop_,
 }
 
-fn setup() {
+fn setup(_: App) {
     UsbSerial.begin(BAUD_RATE);
 }
 
-fn loop_() {
+fn loop_(ref mut app: App) {
     // Get Device ID
     let device_id = hal::device_id();
 
@@ -36,5 +37,5 @@ fn loop_() {
     UsbSerial.write(b'\n');
     UsbSerial.write(b'\r');
 
-    hal::sleep_ms(PERIOD);
+    app.delay_ms(PERIOD);
 }

--- a/examples/function.rs
+++ b/examples/function.rs
@@ -10,10 +10,11 @@
 
 #![no_std]
 
-extern crate particle_hal as hal;
 #[macro_use]
 extern crate photon;
+extern crate photon_hal as hal;
 
+use photon::{App, Cloud};
 use hal::{D7, PinMode, String, cloud};
 
 app! {
@@ -21,19 +22,19 @@ app! {
     loop: loop_,
 }
 
-fn setup() {
+fn setup(_: App) {
     D7.pin_mode(PinMode::Output);
 
-    if cloud::function("led", toggle).is_ok() {
+    if cloud::function("led", led).is_ok() {
         D7.high();
     } else {
         D7.low();
     }
 }
 
-fn loop_() {}
+fn loop_(_: App) {}
 
-extern "C" fn toggle(command: &String) -> i32 {
+extern "C" fn led(command: &String, _: Cloud) -> i32 {
     if &**command == b"on" {
         D7.high();
         1

--- a/examples/heartbeat.rs
+++ b/examples/heartbeat.rs
@@ -2,31 +2,32 @@
 
 #![no_std]
 
-extern crate particle_hal as hal;
 #[macro_use]
 extern crate photon;
+extern crate photon_hal as hal;
 
 use hal::{D7, PinMode};
+use photon::App;
 
 app! {
     setup: setup,
     loop: loop_,
 }
 
-fn setup() {
+fn setup(_: App) {
     D7.pin_mode(PinMode::Output);
 }
 
-fn loop_() {
+fn loop_(ref mut app: App) {
     D7.high();
-    hal::sleep_ms(200);
+    app.delay_ms(200);
 
     D7.low();
-    hal::sleep_ms(50);
+    app.delay_ms(50);
 
     D7.high();
-    hal::sleep_ms(250);
+    app.delay_ms(250);
 
     D7.low();
-    hal::sleep_ms(500);
+    app.delay_ms(500);
 }

--- a/examples/led.rs
+++ b/examples/led.rs
@@ -2,20 +2,21 @@
 
 #![no_std]
 
-extern crate particle_hal as hal;
 #[macro_use]
 extern crate photon;
+extern crate photon_hal as hal;
 
 use hal::{LED, PinMode};
+use photon::App;
 
 app! {
     setup: setup,
     loop: loop_,
 }
 
-fn setup() {
+fn setup(_: App) {
     LED.pin_mode(PinMode::Output);
     LED.high();
 }
 
-fn loop_() {}
+fn loop_(_: App) {}

--- a/examples/usbserial.rs
+++ b/examples/usbserial.rs
@@ -2,11 +2,12 @@
 
 #![no_std]
 
-extern crate particle_hal as hal;
 #[macro_use]
 extern crate photon;
+extern crate photon_hal as hal;
 
 use hal::UsbSerial;
+use photon::App;
 
 const PERIOD: u32 = 100; // ms
 const BAUD_RATE: u32 = 115_200;
@@ -16,13 +17,13 @@ app! {
     loop: loop_,
 }
 
-fn setup() {
+fn setup(_: App) {
     UsbSerial.begin(BAUD_RATE);
 }
 
-fn loop_() {
+fn loop_(ref mut app: App) {
     for byte in b"Rust " {
         UsbSerial.write(*byte);
-        hal::sleep_ms(PERIOD);
+        app.delay_ms(PERIOD);
     }
 }

--- a/examples/variable.rs
+++ b/examples/variable.rs
@@ -1,12 +1,16 @@
 //! Example for the Particle.variable API
 
+#![feature(const_fn)]
 #![no_std]
 
-extern crate particle_hal as hal;
 #[macro_use]
 extern crate photon;
+extern crate photon_hal as hal;
+
+use core::cell::Cell;
 
 use hal::{LED, PinMode, cloud};
+use photon::{App, Resource};
 
 app! {
     setup: setup,
@@ -14,26 +18,25 @@ app! {
 }
 
 const PERIOD: u32 = 1_000;
-static mut COUNTER: i32 = 0;
+static COUNT: Resource<Cell<i32>> = Resource::new(Cell::new(0));
 
-fn setup() {
+fn setup(ref app: App) {
     LED.pin_mode(PinMode::Output);
 
-    if cloud::variable("counter", unsafe { &COUNTER }).is_ok() {
+    if cloud::variable("count", COUNT.access(app)).is_ok() {
         LED.high()
     } else {
         LED.low()
     }
 }
 
-fn loop_() {
+fn loop_(ref mut app: App) {
     LED.high();
-    hal::sleep_ms(PERIOD / 2);
+    app.delay_ms(PERIOD / 2);
 
     LED.low();
-    hal::sleep_ms(PERIOD / 2);
+    app.delay_ms(PERIOD / 2);
 
-    unsafe {
-        COUNTER += 1;
-    }
+    let count = COUNT.access(app);
+    count.set(count.get() + 1);
 }


### PR DESCRIPTION
this commit allow lock-less memory safe data sharing between the "main" context,
the `setup` / `loop` functions, and cloud functions through the `Resource`
abstraction.

`Resource`s are global variables that are safe to access from different
contexts. Safety is enforced in two ways:

Single context memory safety: The `Resource.access{,_mut}` methods take a
"context" token, `App` or `Cloud`, to preserve Rust borrowing rules: only one
mutable reference (`&mut -`) OR several shared references (`&-`) may exist at
any given time. This rule prevents pointer invalidation. This is the kind of
problem we prevent at compile time:

``` rust
fn loop_(ref mut app: App) {
    static OWNED: Resource<Option<i32>> = Resource::new(Some(0));

    let owned = OWNED.access(app);
    let shared_ref: &i32 = owned.as_ref().unwrap();
    let mut_ref = OWNED.access_mut(app);
    // ~^ compile error (`app` has been frozen by the `shared_ref` borrow)

    // `OWNED` changed to `None`. `shared_ref` has been invalidated
    *mut_ref.as_mut().unwrap() = None;

    let bad = *shared_ref;
}
```

Memory safety during preemption: If SYSTEM_THREAD is not enabled, which is our
case, then cloud functions can *only* preempt the main context, `loop` /
`setup`, when the `App.delay_ms` method is called. To ensure no pointer
invalidation occurs in that case a `App.delay_ms` call won't compile if there
are outstanding borrows to resources in the current context. This is the kind of
problem we prevent at compile time:

``` rust
static SHARED: Resource<Option<i32>> = Resource::new(Some(0));

fn loop_(ref mut app: App) {
    let shared = SHARED.access(app);
    let shared_ref: &i32 = shared.as_ref().unwrap();

    // `task` preempts this context during the delay
    app.delay_ms(100);
    //~^ compile error (`app` has been frozen by the `shared_ref` borrow)

    // `shared_ref` would have been invalidated at this point because `SHARED`
    // now contains a `None` variant
    let bad = *shared_ref;
}

fn task(_: String, ref mut cloud: Cloud) {
    // "empties" the SHARED resource
    *SHARED.access_mut(cloud) = None;
}
```

cc @dbrgn the function and variable examples are now fully safe